### PR TITLE
[Xcode11]Fix Layout system.

### DIFF
--- a/BottomSheetUI/Base.lproj/Main.storyboard
+++ b/BottomSheetUI/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,8 +22,9 @@
                                 <color key="textColor" red="0.30267238619999998" green="0.66678375010000002" blue="0.65887558459999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tGn-aN-8Bt">
+                            <containerView opaque="NO" contentMode="scaleToFill" id="tGn-aN-8Bt">
                                 <rect key="frame" x="0.0" y="603" width="375" height="64"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="64" id="du3-bb-luw"/>
                                 </constraints>
@@ -98,6 +97,7 @@
                             <constraint firstItem="5dd-pb-jlm" firstAttribute="centerX" secondItem="0OR-mP-G9l" secondAttribute="centerX" id="nOk-lV-Y4P"/>
                             <constraint firstAttribute="bottom" secondItem="1t5-I2-XMh" secondAttribute="bottom" id="sdM-Y1-8x1"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="WAB-Gz-luP"/>
                     </view>
                     <size key="freeformSize" width="375" height="567"/>
                     <connections>
@@ -111,6 +111,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="img_arrow_down_guide" width="36" height="11"/>
+        <image name="img_arrow_down_guide" width="36" height="11.5"/>
     </resources>
 </document>


### PR DESCRIPTION
## Contents

* fix bottom sheet UI

Due to change of Layout system from iOS 13.

<img width="258" alt="スクリーンショット 2020-03-24 21 16 51" src="https://user-images.githubusercontent.com/8732417/77427254-67a00700-6e19-11ea-9f1f-3be31d004977.png">

### FYI
https://stackoverflow.com/questions/57597413/ios-13-animating-view-not-changing-frame

## Screen Shot(GIF)
![RPReplay_Final1585052147](https://user-images.githubusercontent.com/8732417/77426487-ee53e480-6e17-11ea-9322-8630f23f2344.gif)

